### PR TITLE
Add support for redmine 2.x and add configurable default landing pages

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,21 @@
 = redmine_landing_page
 
-Landing Page plugin for redmine. Tested with redmine 1.1.2 and 1.3.0.
+Landing Page plugin for redmine. Tested with redmine 1.1.2, 1.3.0, 1.4.x and 2.x.
 
-Install to redmine/vendor/plugins directory and run rake db:migrate_plugins.
+For 1.X.X branches:
+  * install to redmine/vendor/plugins directory
+  * run the command: rake db:migrate_plugins
+  * restart webserver
+
+For 2.X.X branches:
+  * install to redmine/plugins directory
+  * run the command: rake redmine:plugins:migrate
+  * restart webserver
+
+= Using the plugin
+
+Open the administration panel and go to a user. There is a new input box, which is their landing page. Set it to the page wanted.
+
+You can also set the landing page for a project, by going to the project settings, and filling in the input box there.
+
+The default landing pages can be changed in the plugin configuration under administration panel -> plugins.

--- a/app/views/landing_page/_landing_page_settings.html.erb
+++ b/app/views/landing_page/_landing_page_settings.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= label_tag("settings[default_landing_page]", l(:label_default_landing_page)) %>
+  <%= text_field_tag("settings[default_landing_page]", @settings["default_landing_page"], :placeholder => "projects") %>  
+</p>
+<p>
+  <%= label_tag("settings[default_project_landing_page]", l(:label_default_project_landing_page)) %>
+  <%= text_field_tag("settings[default_project_landing_page]", @settings["default_project_landing_page"], :placeholder => "issues/gantt") %>
+</p>

--- a/app/views/my/_landing_page.html.erb
+++ b/app/views/my/_landing_page.html.erb
@@ -1,1 +1,1 @@
-<p><%= form.text_field :landing_page, :style => 'width: 90%', :placeholder => "#{request.scheme}://#{request.host_with_port}/projects/demo/wiki/Wiki" %></p>
+<p><%= form.text_field :landing_page, :style => 'width: 90%', :placeholder => "my/page" %></p>

--- a/app/views/projects/_landing_page.html.erb
+++ b/app/views/projects/_landing_page.html.erb
@@ -1,1 +1,1 @@
-<p><%= form.text_field :landing_page, :size => 60, :placeholder => "#{request.scheme}://#{request.host_with_port}/projects/demo/wiki/Wiki" %></p>
+<p><%= form.text_field :landing_page, :size => 60, :placeholder => "news" %></p>

--- a/app/views/users/_landing_page.html.erb
+++ b/app/views/users/_landing_page.html.erb
@@ -1,1 +1,1 @@
-<p><%= form.text_field :landing_page, :style => 'width: 90%', :placeholder => "#{request.scheme}://#{request.host_with_port}/projects/demo/wiki/Wiki"  %></p>
+<p><%= form.text_field :landing_page, :style => 'width: 90%', :placeholder => "my/page"  %></p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,5 @@
 # German translation by Tobias Fischer https://github.com/paginagmbh
 de:
   field_landing_page: "Startseite"
+  label_default_landing_page: "Standard Startseite für Redmine"
+  label_default_project_landing_page: "Standard Startseite für Projekte"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
 # English strings go here for Rails i18n
 en:
   field_landing_page: "Landing Page"
+  label_default_landing_page: "Default Landing Page for Redmine"
+  label_default_project_landing_page: "Default Landing Page for projects"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,12 @@
+# Plugin's routes
+# See: http://guides.rubyonrails.org/routing.html
+
+if Rails::VERSION::MAJOR >= 3
+  match '/projects/:id/:overview', :to => 'projects#show', :constraints => {:overview => 'overview'}
+  match '/:main', :to => 'welcome#index', :constraints => {:main => 'welcome'}
+else
+  ActionController::Routing::Routes.draw do |map|
+    map.connect '/projects/:id/:overview', :controller => 'projects', :action => 'show', :requirements => {:overview => /overview/}
+    map.connect '/:main', :controller => 'welcome', :action => 'index', :requirements => {:main => /welcome/}
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -9,19 +9,36 @@ Redmine::Plugin.register :redmine_landing_page do
   author_url 'https://github.com/biow0lf'
 end
 
-require 'dispatcher'
-Dispatcher.to_prepare :redmine_contracts do
-  require_dependency 'projects_controller'
-  ProjectsController.send(:include, RedmineLandingPage::Patches::ProjectsControllerPatch)
+require 'dispatcher' unless Rails::VERSION::MAJOR >= 3
 
-  require_dependency 'project'
-  Project.send(:include, RedmineLandingPage::Patches::ProjectPatch)
+if Rails::VERSION::MAJOR >= 3
+  ActionDispatch::Callbacks.to_prepare do
+    require_dependency 'projects_controller'
+    ProjectsController.send(:include, RedmineLandingPage::Patches::ProjectsControllerPatch)
 
-  require_dependency 'principal'
-  User.send(:include, RedmineLandingPage::Patches::UserPatch)
+    require_dependency 'project'
+    Project.send(:include, RedmineLandingPage::Patches::ProjectPatch)
 
-  require_dependency 'welcome_controller'
-  WelcomeController.send(:include, RedmineLandingPage::Patches::WelcomeControllerPatch)
+    require_dependency 'principal'
+    User.send(:include, RedmineLandingPage::Patches::UserPatch)
+
+    require_dependency 'welcome_controller'
+    WelcomeController.send(:include, RedmineLandingPage::Patches::WelcomeControllerPatch)
+  end
+else
+  Dispatcher.to_prepare :redmine_contracts do
+    require_dependency 'projects_controller'
+    ProjectsController.send(:include, RedmineLandingPage::Patches::ProjectsControllerPatch)
+
+    require_dependency 'project'
+    Project.send(:include, RedmineLandingPage::Patches::ProjectPatch)
+
+    require_dependency 'principal'
+    User.send(:include, RedmineLandingPage::Patches::UserPatch)
+
+    require_dependency 'welcome_controller'
+    WelcomeController.send(:include, RedmineLandingPage::Patches::WelcomeControllerPatch)
+  end
 end
 
 require 'redmine_landing_page/hooks/view_projects_form_hook'

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,16 @@ Redmine::Plugin.register :redmine_landing_page do
   version '0.0.2'
   url 'https://github.com/biow0lf/redmine_landing_page'
   author_url 'https://github.com/biow0lf'
+
+  delete_menu_item :top_menu, :home
+  menu :top_menu, :home, { :controller => 'welcome', :action => 'index', :main => 'welcome' }, :caption => :label_home, :before => :my_page
+
+  delete_menu_item :project_menu, :overview
+  menu :project_menu, :overview, { :controller => 'projects', :action => 'show', :overview => 'overview' }, :caption => :label_overview, :before => :activity, :param => :id
+
+  settings :default => {"default_landing_page" => "",
+                        "default_project_landing_page" => ""},
+           :partial => "landing_page/landing_page_settings"
 end
 
 require 'dispatcher' unless Rails::VERSION::MAJOR >= 3

--- a/init.rb
+++ b/init.rb
@@ -4,7 +4,7 @@ Redmine::Plugin.register :redmine_landing_page do
   name 'Redmine Landing Page plugin'
   author 'Igor Zubkov'
   description 'Redmine Landing Page plugin'
-  version '0.0.2'
+  version '1.0.0'
   url 'https://github.com/biow0lf/redmine_landing_page'
   author_url 'https://github.com/biow0lf'
 

--- a/lib/redmine_landing_page/patches/projects_controller_patch.rb
+++ b/lib/redmine_landing_page/patches/projects_controller_patch.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module RedmineLandingPage
   module Patches
     module ProjectsControllerPatch
@@ -8,10 +10,20 @@ module RedmineLandingPage
           alias_method :show_without_landing_page, :show unless method_defined? :show_without_landing_page
 
           def show
+            landing_page = Setting["plugin_redmine_landing_page"]["default_project_landing_page"]            
             if @project.landing_page && !@project.landing_page.empty?
-              redirect_to @project.landing_page, :status => 302
+              landing_page = @project.landing_page
+            end
+            
+            if landing_page && !landing_page.empty? && params[:overview] == nil && params[:jump] == nil
+              current_uri = URI(landing_page)
+              if current_uri.relative?                
+                landing_page = URI(request.url + "/").merge(landing_page).to_s
+              end
+              redirect_to landing_page, :status => 302
             else
-              show_without_landing_page
+              params.delete(:overview)
+              show_without_landing_page              
             end
           end
         end

--- a/lib/redmine_landing_page/patches/welcome_controller_patch.rb
+++ b/lib/redmine_landing_page/patches/welcome_controller_patch.rb
@@ -7,13 +7,23 @@ module RedmineLandingPage
 
           alias_method :index_without_landing_page, :index unless method_defined? :index_without_landing_page
 
-          def index
+          def index            
+            landing_page = Setting["plugin_redmine_landing_page"]["default_landing_page"]            
             if User.current.logged? &&
                User.current.landing_page &&
                !User.current.landing_page.empty?
-              redirect_to User.current.landing_page, :status => 302
+              landing_page = User.current.landing_page
+            end
+            
+            if landing_page && !landing_page.empty? && params[:main] == nil
+              current_uri = URI(landing_page)
+              if current_uri.relative?                
+                landing_page = URI(request.url + "/").merge(landing_page).to_s
+              end
+              redirect_to landing_page, :status => 302
             else
-              index_without_landing_page
+              params.delete(:main)
+              index_without_landing_page              
             end
           end
         end


### PR DESCRIPTION
This basically reverts previous changes since the fork and just makes sure that this branch has the same version as 
https://github.com/biow0lf/redmine_landing_page (branch master)
as soon as 
https://github.com/biow0lf/redmine_landing_page/pull/8
gets merged, to reduce confusion for others
